### PR TITLE
Enable right-click erase

### DIFF
--- a/docs/draw/controls/index.html
+++ b/docs/draw/controls/index.html
@@ -20,6 +20,7 @@
     <p>click and drag to draw</p>
     <p>use the color picker and size slider to change your brush</p>
     <p>press clear to erase everything</p>
+    <p>hold right click to temporarily use the eraser</p>
     <a href="javascript:history.back()">go back</a>
 </body>
 <script>

--- a/docs/draw/draw.js
+++ b/docs/draw/draw.js
@@ -16,6 +16,8 @@ window.addEventListener('DOMContentLoaded', () => {
     let currentHistoryIndex = -1; // Track current position in history
     let selectedBrushType = 'square'; // Default brush type
     let isFilling = false; // Flag to prevent multiple fill operations
+    let prevBrushType = null; // Store previous brush when right-click erasing
+    let rightClickErasing = false; // Track right click erase state
 
     function getPos(e) {
         const rect = canvas.getBoundingClientRect();
@@ -38,6 +40,13 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     function start(e) {
+        if (e.button === 2) {
+            rightClickErasing = true;
+            prevBrushType = selectedBrushType;
+            if (selectedBrushType !== 'eraser') {
+                setActiveBrushType('eraser');
+            }
+        }
         drawing = true;
         const pos = getPos(e);
         lastPos = pos;
@@ -497,13 +506,20 @@ window.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function stop() {
+    function stop(e) {
         if (drawing) {
             // Save canvas state when drawing ends
             saveCanvasState();
         }
         drawing = false;
         lastPos = null;
+
+        if (rightClickErasing && e && e.button === 2) {
+            rightClickErasing = false;
+            if (prevBrushType) {
+                setActiveBrushType(prevBrushType);
+            }
+        }
     }
 
     function resizeCanvas(size) {
@@ -560,6 +576,7 @@ window.addEventListener('DOMContentLoaded', () => {
     canvas.addEventListener('mousedown', start);
     canvas.addEventListener('mousemove', draw);
     window.addEventListener('mouseup', stop);
+    canvas.addEventListener('contextmenu', (e) => e.preventDefault());
 
     canvas.addEventListener('touchstart', (e) => { e.preventDefault(); start(e); });
     canvas.addEventListener('touchmove', (e) => { e.preventDefault(); draw(e); });
@@ -608,15 +625,17 @@ window.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function setActiveBrushType(type) {
+        document.querySelectorAll('.brush-type').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.type === type);
+        });
+        selectedBrushType = type;
+    }
+
     // Handle brush type selection
     document.querySelectorAll('.brush-type').forEach(button => {
         button.addEventListener('click', () => {
-            // Remove active class from all brush type buttons
-            document.querySelectorAll('.brush-type').forEach(btn => btn.classList.remove('active'));
-            // Add active class to clicked button
-            button.classList.add('active');
-            // Update selected brush type
-            selectedBrushType = button.dataset.type;
+            setActiveBrushType(button.dataset.type);
         });
     });
 
@@ -695,7 +714,6 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 // todo:
-// make right click erase
 // add zoom
 // add select
 // add type


### PR DESCRIPTION
## Summary
- allow right click on the canvas to temporarily use the eraser tool
- prevent the browser context menu from appearing when right-clicking the canvas
- update controls docs with instructions for using right click

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bbc7c9e5c832199b663ce54fb69a6