### PR TITLE
Add layer controls with previews

### DIFF
--- a/docs/draw/draw.css
+++ b/docs/draw/draw.css
@@ -90,20 +90,6 @@ main {
     cursor: pointer;
 }
 
-#canvas {
-    background-color: #e0e0e0;
-    touch-action: none;
-    width: 80vmin;
-    height: 80vmin;
-    image-rendering: pixelated;
-    image-rendering: -moz-crisp-edges;
-    image-rendering: crisp-edges;
-    border: 1px solid var(--text-color);
-}
-
-.dark-mode #canvas {
-    background-color: #202020;
-}
 
 .palette-controls {
     display: flex;
@@ -213,6 +199,54 @@ select:hover {
     font-size: 16px;
     margin-bottom: 4px;
     text-align: left;
+}
+
+/* Layering styles */
+#canvas-stack {
+    position: relative;
+    width: 80vmin;
+    height: 80vmin;
+    background-color: #e0e0e0;
+    border: 1px solid var(--text-color);
+}
+
+.dark-mode #canvas-stack {
+    background-color: #202020;
+}
+
+.drawing-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    image-rendering: pixelated;
+}
+
+.layers-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.layer-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.layer-item.active {
+    outline: 2px solid grey;
+}
+
+.layer-preview {
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--text-color);
+    image-rendering: pixelated;
 }
 
 

--- a/docs/draw/draw.js
+++ b/docs/draw/draw.js
@@ -1,6 +1,5 @@
 window.addEventListener('DOMContentLoaded', () => {
-    const canvas = document.getElementById('canvas');
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const canvasContainer = document.getElementById('canvas-stack');
     const canvasSizeSelect = document.getElementById('canvas-size');
     const colorPalette = document.getElementById('color-palette');
     const editButton = document.getElementById('edit-button');
@@ -12,6 +11,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const saveConfirm = document.getElementById('save-confirm');
     const saveCancel = document.getElementById('save-cancel');
     const saveError = document.getElementById('save-error');
+    const addLayerButton = document.getElementById('add-layer-button');
+    const layersList = document.getElementById('layers-list');
+
+    let layers = [];
+    let activeLayerIndex = 0;
+    let canvas;
+    let ctx;
 
     let drawing = false;
     let canvasSize = 16; // Default size
@@ -26,23 +32,90 @@ window.addEventListener('DOMContentLoaded', () => {
     let prevBrushType = null; // Store previous brush when right-click erasing
     let rightClickErasing = false; // Track right click erase state
 
+    function createLayer() {
+        const layerCanvas = document.createElement('canvas');
+        layerCanvas.width = 16;
+        layerCanvas.height = 16;
+        layerCanvas.className = 'drawing-layer';
+        layerCanvas.style.opacity = '1';
+        layerCanvas.style.pointerEvents = 'none';
+        canvasContainer.appendChild(layerCanvas);
+
+        const preview = document.createElement('canvas');
+        preview.width = 16;
+        preview.height = 16;
+        preview.className = 'layer-preview';
+
+        const alphaInput = document.createElement('input');
+        alphaInput.type = 'range';
+        alphaInput.min = '0';
+        alphaInput.max = '1';
+        alphaInput.step = '0.01';
+        alphaInput.value = '1';
+
+        const item = document.createElement('div');
+        item.className = 'layer-item';
+        item.appendChild(preview);
+        item.appendChild(alphaInput);
+        layersList.appendChild(item);
+
+        const ctx = layerCanvas.getContext('2d', { willReadFrequently: true });
+        const layer = { canvas: layerCanvas, ctx, preview, previewCtx: preview.getContext('2d'), alphaInput, item, size: 16, history: [], historyIndex: -1 };
+        layers.push(layer);
+
+        item.addEventListener('click', () => selectLayer(layers.indexOf(layer)));
+        alphaInput.addEventListener('input', () => {
+            layerCanvas.style.opacity = alphaInput.value;
+            layer.alpha = parseFloat(alphaInput.value);
+        });
+
+        updatePreview(layer);
+
+        if (layers.length === 1) {
+            selectLayer(0);
+        }
+    }
+
+    function updatePreview(layer) {
+        layer.previewCtx.clearRect(0, 0, layer.preview.width, layer.preview.height);
+        layer.previewCtx.drawImage(layer.canvas, 0, 0, layer.preview.width, layer.preview.height);
+    }
+
+    function selectLayer(index) {
+        if (layers[activeLayerIndex]) {
+            layers[activeLayerIndex].canvas.style.pointerEvents = 'none';
+            layers[activeLayerIndex].item.classList.remove('active');
+            layers[activeLayerIndex].history = canvasHistory;
+            layers[activeLayerIndex].historyIndex = currentHistoryIndex;
+        }
+        activeLayerIndex = index;
+        canvas = layers[index].canvas;
+        ctx = layers[index].ctx;
+        canvasSize = layers[index].size;
+        updateBrushSize('5');
+        layers[index].canvas.style.pointerEvents = 'auto';
+        layers[index].item.classList.add('active');
+        canvasSizeSelect.value = canvasSize.toString();
+        canvasHistory = layers[index].history;
+        currentHistoryIndex = layers[index].historyIndex;
+    }
+
     function getPos(e) {
-        const rect = canvas.getBoundingClientRect();
+        const rect = canvasContainer.getBoundingClientRect();
         let x, y;
         if (e.touches) {
             const t = e.touches[0];
             x = t.clientX - rect.left;
             y = t.clientY - rect.top;
         } else {
-            x = e.offsetX;
-            y = e.offsetY;
+            x = e.clientX - rect.left;
+            y = e.clientY - rect.top;
         }
-        // Scale coordinates to match the canvas size
         const scaleX = canvas.width / rect.width;
         const scaleY = canvas.height / rect.height;
-        return { 
-            x: Math.floor(x * scaleX), 
-            y: Math.floor(y * scaleY) 
+        return {
+            x: Math.floor(x * scaleX),
+            y: Math.floor(y * scaleY)
         };
     }
 
@@ -627,15 +700,15 @@ window.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function resizeCanvas(size) {
-        const oldSize = canvasSize;
-        const oldData = ctx.getImageData(0, 0, oldSize, oldSize);
+    function resizeLayer(layer, size) {
+        const oldSize = layer.size;
+        const oldData = layer.ctx.getImageData(0, 0, oldSize, oldSize);
 
-        canvasSize = size;
-        canvas.width = size;
-        canvas.height = size;
+        layer.size = size;
+        layer.canvas.width = size;
+        layer.canvas.height = size;
 
-        const newImageData = ctx.createImageData(size, size);
+        const newImageData = layer.ctx.createImageData(size, size);
 
         if (size > oldSize) {
             // Scale up: keep old pixels centred and add empty space around
@@ -692,13 +765,14 @@ window.addEventListener('DOMContentLoaded', () => {
             newImageData.data.set(oldData.data);
         }
 
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.putImageData(newImageData, 0, 0);
+        layer.ctx.clearRect(0, 0, layer.canvas.width, layer.canvas.height);
+        layer.ctx.putImageData(newImageData, 0, 0);
 
         updateBrushSize('5');
         canvasHistory = [];
         currentHistoryIndex = -1;
         saveCanvasState();
+        updatePreview(layer);
     }
 
     function saveCanvasState() {
@@ -717,6 +791,8 @@ window.addEventListener('DOMContentLoaded', () => {
             canvasHistory.shift();
             currentHistoryIndex--;
         }
+
+        updatePreview(layers[activeLayerIndex]);
     }
 
     function undo() {
@@ -724,6 +800,7 @@ window.addEventListener('DOMContentLoaded', () => {
             currentHistoryIndex--;
             const previousState = canvasHistory[currentHistoryIndex];
             ctx.putImageData(previousState, 0, 0);
+            updatePreview(layers[activeLayerIndex]);
         }
     }
 
@@ -732,22 +809,31 @@ window.addEventListener('DOMContentLoaded', () => {
             currentHistoryIndex++;
             const nextState = canvasHistory[currentHistoryIndex];
             ctx.putImageData(nextState, 0, 0);
+            updatePreview(layers[activeLayerIndex]);
         }
     }
 
-    canvas.addEventListener('mousedown', start);
-    canvas.addEventListener('mousemove', draw);
+    canvasContainer.addEventListener('mousedown', start);
+    canvasContainer.addEventListener('mousemove', draw);
     window.addEventListener('mouseup', stop);
-    canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+    canvasContainer.addEventListener('contextmenu', (e) => e.preventDefault());
 
-    canvas.addEventListener('touchstart', (e) => { e.preventDefault(); start(e); });
-    canvas.addEventListener('touchmove', (e) => { e.preventDefault(); draw(e); });
-    canvas.addEventListener('touchend', stop);
-    canvas.addEventListener('touchcancel', stop);
+    canvasContainer.addEventListener('touchstart', (e) => { e.preventDefault(); start(e); });
+    canvasContainer.addEventListener('touchmove', (e) => { e.preventDefault(); draw(e); });
+    canvasContainer.addEventListener('touchend', stop);
+    canvasContainer.addEventListener('touchcancel', stop);
 
     // Handle canvas size changes
     canvasSizeSelect.addEventListener('change', (e) => {
-        resizeCanvas(parseInt(e.target.value));
+        const layer = layers[activeLayerIndex];
+        resizeLayer(layer, parseInt(e.target.value));
+        canvasSize = layer.size;
+        updateBrushSize('5');
+        layer.history = [];
+        layer.historyIndex = -1;
+        canvasHistory = layer.history;
+        currentHistoryIndex = layer.historyIndex;
+        updatePreview(layer);
     });
 
     // Handle brush size selection
@@ -821,8 +907,14 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // Initialize canvas with default size
-    resizeCanvas(16);
+    // Initialize first layer
+    createLayer();
+
+    addLayerButton.addEventListener('click', () => {
+        if (layers.length < 5) {
+            createLayer();
+        }
+    });
     
     // Set initial brush size
     updateBrushSize('5'); // Start with S size
@@ -898,6 +990,7 @@ window.addEventListener('DOMContentLoaded', () => {
     clearButton.addEventListener('click', () => {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         saveCanvasState();
+        updatePreview(layers[activeLayerIndex]);
     });
 
     // Save canvas functionality

--- a/docs/draw/index.html
+++ b/docs/draw/index.html
@@ -66,6 +66,10 @@
                         <button id="edit-button">edit</button>
                         <button id="reset-button">reset</button>
                     </div>
+                    <div class="layers-section">
+                        <button id="add-layer-button">add layer</button>
+                        <div id="layers-list"></div>
+                    </div>
                     <div class="canvas-controls">
                         <div id="save-input-container" class="save-input-container" style="display: none;">
                             <div id="save-error" class="save-error" style="display: none;">enter a drawing name</div>
@@ -77,7 +81,7 @@
                 </div>
             </div>
             <div class="center-section">
-                <canvas id="canvas" width="16" height="16"></canvas>
+                <div id="canvas-stack"></div>
             </div>
             <div class="right-section">
             </div>


### PR DESCRIPTION
## Summary
- add layer management UI and preview canvases
- style layers and canvas stack
- support multiple drawing layers with opacity controls

## Testing
- `node --check docs/draw/draw.js`

------
https://chatgpt.com/codex/tasks/task_e_687d0e42f1448321a89c98c87fb343db