### PR TITLE
Add image load feature for drawing tool

### DIFF
--- a/docs/draw/draw.css
+++ b/docs/draw/draw.css
@@ -185,10 +185,21 @@ select:hover {
     bottom: calc(1rem + 4px);
 }
 
+#load-button {
+    position: absolute;
+    left: 50%;
+    bottom: calc(1rem + 4px);
+    transform: translateX(-50%);
+}
+
 #clear-button {
     position: absolute;
     right: calc(1rem + 4px);
     bottom: calc(1rem + 4px);
+}
+
+#load-input {
+    display: none;
 }
 
 /* Save input container styling */

--- a/docs/draw/draw.css
+++ b/docs/draw/draw.css
@@ -187,9 +187,8 @@ select:hover {
 
 #load-button {
     position: absolute;
-    left: 50%;
+    left: calc(1rem + 4px + 40px); /* save button width + gap */
     bottom: calc(1rem + 4px);
-    transform: translateX(-50%);
 }
 
 #clear-button {

--- a/docs/draw/draw.js
+++ b/docs/draw/draw.js
@@ -375,6 +375,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
     function loadImageFromFile(file) {
         const img = new Image();
+        const objectURL = URL.createObjectURL(file);
+        
         img.onload = () => {
             const width = img.width;
             const height = img.height;
@@ -396,10 +398,19 @@ window.addEventListener('DOMContentLoaded', () => {
                 ctx.drawImage(img, 0, 0, width, height, 0, 0, closest, closest);
             }
             saveCanvasState();
-            URL.revokeObjectURL(img.src);
+            URL.revokeObjectURL(objectURL);
             loadInput.value = '';
         };
-        img.src = URL.createObjectURL(file);
+        
+        img.onerror = () => {
+            // Handle image loading errors
+            console.error('Failed to load image:', file.name);
+            URL.revokeObjectURL(objectURL);
+            loadInput.value = '';
+            // Optionally show user feedback here
+        };
+        
+        img.src = objectURL;
     }
 
     function drawBackSlashBrush(pos) {
@@ -974,4 +985,5 @@ window.addEventListener('DOMContentLoaded', () => {
 //// qwe
 ////  sd
 ////  xc
+//// space
 //// space

--- a/docs/draw/draw.js
+++ b/docs/draw/draw.js
@@ -7,6 +7,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const resetButton = document.getElementById('reset-button');
     const clearButton = document.getElementById('clear-button');
     const saveButton = document.getElementById('save-button');
+    const loadButton = document.getElementById('load-button');
+    const loadInput = document.getElementById('load-input');
     const saveInputContainer = document.getElementById('save-input-container');
     const saveFilename = document.getElementById('save-filename');
     const saveConfirm = document.getElementById('save-confirm');
@@ -369,6 +371,35 @@ window.addEventListener('DOMContentLoaded', () => {
             // Hide the input after successful save
             hideSaveInput();
         }, 'image/png');
+    }
+
+    function loadImageFromFile(file) {
+        const img = new Image();
+        img.onload = () => {
+            const width = img.width;
+            const height = img.height;
+            const sizes = Array.from(canvasSizeSelect.options).map(opt => parseInt(opt.value));
+            if (width === height && sizes.includes(width)) {
+                resizeCanvas(width);
+                canvasSizeSelect.value = String(width);
+                ctx.drawImage(img, 0, 0);
+            } else {
+                const minSide = Math.min(width, height);
+                let closest = sizes[0];
+                for (const s of sizes) {
+                    if (Math.abs(s - minSide) < Math.abs(closest - minSide)) {
+                        closest = s;
+                    }
+                }
+                resizeCanvas(closest);
+                canvasSizeSelect.value = String(closest);
+                ctx.drawImage(img, 0, 0, width, height, 0, 0, closest, closest);
+            }
+            saveCanvasState();
+            URL.revokeObjectURL(img.src);
+            loadInput.value = '';
+        };
+        img.src = URL.createObjectURL(file);
     }
 
     function drawBackSlashBrush(pos) {
@@ -908,6 +939,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // Save cancel button
     saveCancel.addEventListener('click', hideSaveInput);
+
+    // Load image functionality
+    loadButton.addEventListener('click', () => loadInput.click());
+    loadInput.addEventListener('change', (e) => {
+        if (e.target.files && e.target.files[0]) {
+            loadImageFromFile(e.target.files[0]);
+        }
+    });
 
     // Handle Enter key in save input
     saveFilename.addEventListener('keydown', (e) => {

--- a/docs/draw/index.html
+++ b/docs/draw/index.html
@@ -84,6 +84,8 @@
         </div>
         
         <button id="save-button" class="page-button">save</button>
+        <button id="load-button" class="page-button">load</button>
+        <input id="load-input" type="file" accept="image/*" style="display: none;">
         <button id="clear-button" class="page-button">clear</button>
         
     </main>


### PR DESCRIPTION
## Summary
- allow drawing canvas to load a user image
- center new `load` button and hidden file input on the draw page
- resize canvas to image if square or choose nearest size and squish

## Testing
- `node -c docs/draw/draw.js`

------
https://chatgpt.com/codex/tasks/task_e_687c910f24608321aab1ebdd536c4786