### PR TITLE
Add YouTube beat pad template

### DIFF
--- a/docs/beatpad/index.html
+++ b/docs/beatpad/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>beat pad</title>
+    <!-- prevents fouc -->
+    <style>
+        html.js-loading {
+            visibility: hidden;
+            opacity: 0;
+        }
+    </style>
+    <script>document.documentElement.classList.add('js-loading');</script>
+    <link rel="stylesheet" href="../css/global.css">
+    <link rel="stylesheet" href="../css/header.css">
+    <link rel="stylesheet" href="../css/link.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+    <button id="dark-toggle" class="page-button">dark mode</button>
+    <a href="../"><button id="home-button" class="page-button">o_t</button></a>
+    <h2>BEAT PAD</h2>
+</header>
+<main>
+    <div id="edit-mode">
+        <div class="video-input">
+            <input type="text" id="video-url" placeholder="YouTube link">
+            <button id="load-video">load</button>
+        </div>
+        <div id="player-container">
+            <div id="player"></div>
+        </div>
+        <div class="controls">
+            <button id="set-start">set start</button>
+            <button id="set-end">set end</button>
+            <input type="text" id="key-input" placeholder="key">
+            <button id="add-mapping">add mapping</button>
+        </div>
+        <table id="mappings-table">
+            <thead>
+                <tr><th>key</th><th>start</th><th>end</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <button id="play-mode-btn">enter play mode</button>
+    </div>
+    <div id="play-mode" style="display:none;">
+        <p>press mapped keys to play clips</p>
+        <button id="exit-play-mode">return to edit</button>
+    </div>
+</main>
+<footer>
+    <p>o_t</p>
+</footer>
+<script src="../scripts/darkmode.js"></script>
+<script src="../scripts/fouc.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/docs/beatpad/script.js
+++ b/docs/beatpad/script.js
@@ -1,0 +1,105 @@
+let player;
+let keyMap = {};
+let tempStart = null;
+let tempEnd = null;
+let playMode = false;
+
+function extractVideoId(url) {
+    const reg = /(?:v=|\.be\/|embed\/)([\w-]{11})/;
+    const match = url.match(reg);
+    return match ? match[1] : url;
+}
+
+function onYouTubeIframeAPIReady() {
+    player = new YT.Player('player', {
+        height: '0',
+        width: '0',
+        videoId: '',
+        playerVars: {
+            playsinline: 1
+        },
+        events: {
+            onReady: onPlayerReady
+        }
+    });
+}
+
+function onPlayerReady() {
+    player.mute();
+    player.setPlaybackRate(2);
+    player.playVideo();
+}
+
+function loadVideo() {
+    const url = document.getElementById('video-url').value.trim();
+    if (!url) return;
+    const id = extractVideoId(url);
+    player.loadVideoById(id);
+}
+
+document.getElementById('load-video').addEventListener('click', loadVideo);
+
+document.getElementById('set-start').addEventListener('click', () => {
+    if (player) tempStart = player.getCurrentTime();
+});
+
+document.getElementById('set-end').addEventListener('click', () => {
+    if (player) tempEnd = player.getCurrentTime();
+});
+
+document.getElementById('add-mapping').addEventListener('click', () => {
+    const key = document.getElementById('key-input').value.trim();
+    if (!key || tempStart === null || tempEnd === null) return;
+    keyMap[key] = { start: tempStart, end: tempEnd };
+    tempStart = tempEnd = null;
+    document.getElementById('key-input').value = '';
+    updateTable();
+    localStorage.setItem('beatPadMap', JSON.stringify(keyMap));
+});
+
+document.getElementById('play-mode-btn').addEventListener('click', () => {
+    playMode = true;
+    document.getElementById('edit-mode').style.display = 'none';
+    document.getElementById('play-mode').style.display = 'block';
+    player.setPlaybackRate(1);
+    player.mute();
+    player.playVideo();
+});
+
+document.getElementById('exit-play-mode').addEventListener('click', () => {
+    playMode = false;
+    document.getElementById('edit-mode').style.display = 'block';
+    document.getElementById('play-mode').style.display = 'none';
+});
+
+document.addEventListener('keydown', (e) => {
+    if (!playMode) return;
+    const map = keyMap[e.key];
+    if (!map) return;
+    player.seekTo(map.start, true);
+    player.unMute();
+    player.playVideo();
+    setTimeout(() => {
+        player.mute();
+    }, (map.end - map.start) * 1000);
+});
+
+function updateTable() {
+    const tbody = document.querySelector('#mappings-table tbody');
+    tbody.innerHTML = '';
+    for (const key in keyMap) {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${key}</td><td>${keyMap[key].start.toFixed(2)}</td><td>${keyMap[key].end.toFixed(2)}</td>`;
+        tbody.appendChild(row);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const saved = localStorage.getItem('beatPadMap');
+    if (saved) {
+        try {
+            keyMap = JSON.parse(saved);
+            updateTable();
+        } catch {}
+    }
+});

--- a/docs/beatpad/style.css
+++ b/docs/beatpad/style.css
@@ -1,0 +1,41 @@
+body {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+}
+
+main {
+    width: 100%;
+    max-width: 600px;
+    padding: 1rem;
+    text-align: center;
+}
+
+#player-container {
+    margin-top: 1rem;
+}
+
+.controls {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+}
+
+#mappings-table {
+    margin: 1rem auto;
+    border-collapse: collapse;
+}
+
+#mappings-table th,
+#mappings-table td {
+    border: 1px solid currentColor;
+    padding: 0.25rem 0.5rem;
+}
+
+#play-mode {
+    text-align: center;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,10 @@
                 <a href="mines/" title="yeeowch these little guys hurt">mines</a><br/>
                 try your best to avoid them
             </div>
+            <div class="card">
+                <a href="beatpad/" title="tap out some tunes">beat pad</a><br/>
+                low latency jams
+            </div>
             <!-- <div class="card">
                 <a href="">something else</a><br />
                 im not sure just yet


### PR DESCRIPTION
## Summary
- add `beatpad` page with edit and play modes
- load YouTube IFrame API and map keys to timestamp ranges
- keep mappings in localStorage
- link beat pad from the homepage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888514d8b1c8321ac6551463997f3ca