### PR TITLE
Add seed-based saving for nono game

### DIFF
--- a/docs/nono/index.html
+++ b/docs/nono/index.html
@@ -39,6 +39,11 @@
                 <button class="difficulty-button" id="difficulty-25" data-size="25" data-font="16px">25</button>
                 <button class="difficulty-button" id="difficulty-30" data-size="30" data-font="16px">30</button>
             </div>
+            <div id="seed-controls" class="seed-controls">
+                <button id="copy-seed" class="page-button">copy seed</button>
+                <input id="seed-input" placeholder="seed">
+                <button id="load-seed" class="page-button">load seed</button>
+            </div>
         </div>
 
     </main>


### PR DESCRIPTION
## Summary
- add seed controls to the nono settings panel
- generate a board seed from size and layout and allow loading from a seed
- include the seed in share text when puzzle is solved

## Testing
- `node --check docs/nono/nono.js`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689251da7500832198ff4bf51a60b167