### PR TITLE
Improve homepage responsiveness

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="css/link.css">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="home-page">
     <header>
         <button id="dark-toggle" class="page-button">dark mode</button>
         <h2>OTHER TAB</h2>

--- a/docs/style.css
+++ b/docs/style.css
@@ -9,14 +9,32 @@ body {
     min-height: 100vh;
 }
 
+body.home-page {
+    --home-inline-padding-left: max(1rem, env(safe-area-inset-left, 0px));
+    --home-inline-padding-right: max(1rem, env(safe-area-inset-right, 0px));
+}
+
+body.home-page header,
+body.home-page main {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+body.home-page header {
+    position: relative;
+}
+
 /* card grid  */
 .card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     max-width: 800px;
+    width: 100%;
     gap: 1.5rem;
     margin: auto;
     padding: 1rem;
+    padding-left: var(--home-inline-padding-left, 1rem);
+    padding-right: var(--home-inline-padding-right, 1rem);
     justify-content: center;
     justify-items: center;
 }
@@ -43,3 +61,11 @@ body {
 .dark-mode .card {
     background-color: black;
 }
+
+body.home-page #dark-toggle {
+    position: absolute;
+    top: calc(1rem + 4px);
+    right: calc(var(--home-inline-padding-right, 1rem) + 4px);
+    margin: 0;
+}
+


### PR DESCRIPTION
## Summary
- scope the homepage body with a class to support responsive-only styling
- let the card grid expand to the viewport width with safe-area aware padding for mobile devices
- anchor the dark mode toggle to the header while preserving its desktop placement

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d193df965c8321a76ff5b11817e758