### PR TITLE
Add customizable headers to mobile overlay

### DIFF
--- a/docs/draw/index.html
+++ b/docs/draw/index.html
@@ -108,6 +108,7 @@
         <a href="../privacy/">privacy</a>
     </footer>
 
+    <script src="../scripts/mobile-block.js" data-header="DRAW" data-message="draw works best on a bigger screen, sorry"></script>
     <script src="../scripts/darkmode.js"></script>
     <script src="../scripts/fouc.js"></script>
     <script src="draw.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@
         <a href="privacy/">privacy</a>
     </footer>
 
+    <script src="scripts/mobile-block.js" data-header="OTHER TAB" data-message="other tab isnt really made for mobile, sorry"></script>
     <script src="scripts/darkmode.js"></script>
     <script src="scripts/fouc.js"></script>
 </body>

--- a/docs/mines/index.html
+++ b/docs/mines/index.html
@@ -66,6 +66,7 @@
             <a href="../privacy/">privacy</a>
     </footer>
 
+    <script src="../scripts/mobile-block.js" data-header="MINES" data-message="mines controls are tricky on mobile, sorry"></script>
     <script src="mines.js"></script>
 </body>
 </html>

--- a/docs/nono/index.html
+++ b/docs/nono/index.html
@@ -68,6 +68,7 @@
     <!-- mathjs -->
     <script src="https://cdn.jsdelivr.net/npm/mathjs@14.5.0/lib/browser/math.min.js"></script>
 
+    <script src="../scripts/mobile-block.js" data-header="NONO" data-message="nono puzzles need a desktop-sized display, sorry"></script>
     <script src="../scripts/darkmode.js"></script>
     <script src="../scripts/fouc.js"></script>
     <script src="seed.js"></script>

--- a/docs/scripts/mobile-block.js
+++ b/docs/scripts/mobile-block.js
@@ -1,0 +1,82 @@
+(function () {
+    const currentScript = document.currentScript;
+    const defaultHeader = 'OTHER TAB';
+    const defaultMessage = 'other tab isnt really made for mobile, sorry';
+
+    const customHeader =
+        (currentScript && currentScript.dataset && currentScript.dataset.header) ||
+        (typeof window !== 'undefined' && window.OTHERTAB_MOBILE_HEADER) ||
+        defaultHeader;
+
+    const customMessage =
+        (currentScript && currentScript.dataset && currentScript.dataset.message) ||
+        (typeof window !== 'undefined' && window.OTHERTAB_MOBILE_MESSAGE) ||
+        defaultMessage;
+
+    const mobileRegex = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|Tablet/i;
+    const isTouchDevice = navigator.maxTouchPoints > 1 || 'ontouchstart' in window || 'onpointerdown' in window;
+    const isSmallViewport = window.matchMedia('(max-width: 900px)').matches;
+
+    const isMobileDevice = mobileRegex.test(navigator.userAgent || '') || (isTouchDevice && isSmallViewport);
+
+    if (!isMobileDevice) {
+        return;
+    }
+
+    function showMobileBlocker() {
+        const overlay = document.createElement('div');
+        overlay.setAttribute('role', 'alertdialog');
+        overlay.setAttribute('aria-modal', 'true');
+        overlay.setAttribute('aria-live', 'assertive');
+        overlay.style.position = 'fixed';
+        overlay.style.inset = '0';
+        overlay.style.backgroundColor = '#ffffff';
+        overlay.style.color = '#000000';
+        overlay.style.display = 'flex';
+        overlay.style.alignItems = 'center';
+        overlay.style.justifyContent = 'center';
+        overlay.style.textAlign = 'center';
+        overlay.style.fontFamily = "'Courier New', Courier, monospace";
+        overlay.style.fontSize = '1.25rem';
+        overlay.style.padding = '2rem';
+        overlay.style.zIndex = '2147483647';
+
+        const content = document.createElement('div');
+        content.style.display = 'flex';
+        content.style.flexDirection = 'column';
+        content.style.alignItems = 'center';
+        content.style.gap = '1.5rem';
+        content.style.width = '100%';
+        content.style.maxWidth = '28rem';
+
+        const header = document.createElement('header');
+        header.style.width = '100%';
+        header.style.display = 'flex';
+        header.style.alignItems = 'center';
+        header.style.justifyContent = 'center';
+
+        const heading = document.createElement('h2');
+        heading.textContent = customHeader;
+        heading.style.margin = '1rem 0';
+
+        const message = document.createElement('p');
+        message.textContent = customMessage;
+        message.style.margin = '0';
+        message.style.lineHeight = '1.6';
+
+        header.appendChild(heading);
+        content.appendChild(header);
+        content.appendChild(message);
+        overlay.appendChild(content);
+
+        document.body.innerHTML = '';
+        document.body.appendChild(overlay);
+        document.body.style.overflow = 'hidden';
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', showMobileBlocker);
+    } else {
+        showMobileBlocker();
+    }
+})();

--- a/docs/typing/index.html
+++ b/docs/typing/index.html
@@ -68,6 +68,7 @@
         <a href="../privacy/">privacy</a>
     </footer>
 
+    <script src="../scripts/mobile-block.js" data-header="TYPING" data-message="typing practice is desktop only for now, sorry"></script>
     <script src="../scripts/darkmode.js"></script>
     <script src="../scripts/fouc.js"></script>
     <script type="module" src="typing.js"></script>


### PR DESCRIPTION
## Summary
- support per-page mobile-block header overrides alongside the existing message
- render the blocker overlay with a centered header plus message that matches the site styling
- configure each blocked page to provide its own header label for the overlay

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d88816a2b88321987277ace8d250b3