### PR TITLE
Tighten touch detection for mobile blocker

### DIFF
--- a/docs/scripts/mobile-block.js
+++ b/docs/scripts/mobile-block.js
@@ -13,8 +13,8 @@
         (typeof window !== 'undefined' && window.OTHERTAB_MOBILE_MESSAGE) ||
         defaultMessage;
 
-    // Prefer capability + media features over UA sniffing
-    const isTouchDevice = navigator.maxTouchPoints > 1 || 'ontouchstart' in window || 'onpointerdown' in window;
+    // Prefer capability + media features over UA sniffing, and only treat devices with genuine touch support as touch
+    const isTouchDevice = navigator.maxTouchPoints > 0 || 'ontouchstart' in window;
     const isCoarsePointer = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
     const noHover = window.matchMedia && window.matchMedia('(hover: none)').matches;
     // UA-CH when available (Chromium), fallback to UA regex for Safari/others


### PR DESCRIPTION
## Summary
- narrow the mobile touch detection to only consider genuine touch capabilities
- update the inline documentation to describe the stricter detection

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d977d665588321aecebdac2d8e1a71