### PR TITLE
Add NONO board creator page

### DIFF
--- a/docs/nono-create/index.html
+++ b/docs/nono-create/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="design your own nono boards and share them with friends">
+    <link rel="icon" href="../nono/images/nono.png?v=2" type="image/png" media="(prefers-color-scheme: light)">
+    <link rel="icon" href="../nono/images/nono-dark.png?v=2" type="image/png" media="(prefers-color-scheme: dark)">
+    <title>nono create</title>
+    <!-- prevents fouc, hide style as loading html -->
+    <style>
+        html.js-loading {
+          visibility: hidden;
+          opacity: 0;
+        }
+    </style>
+    <script>document.documentElement.classList.add('js-loading');</script>
+    <link rel="stylesheet" href="../css/global.css">
+    <link rel="stylesheet" href="../css/header.css">
+    <link rel="stylesheet" href="../css/link.css">
+    <link rel="stylesheet" href="nono-create.css">
+</head>
+<body>
+    <header>
+        <a href="../"><button id="home-button" class="page-button">o_t</button></a>
+        <h2>NONO_CREATE</h2>
+        <button id="dark-toggle" class="page-button">dark mode</button>
+    </header>
+
+    <main>
+        <div class="board-area">
+            <table id="creator-board" class="creator-board" aria-label="nono board designer grid"></table>
+        </div>
+        <div id="settings-panel" class="settings-panel hidden" aria-hidden="true">
+            <div class="difficulty-buttons-grid">
+                <button class="difficulty-button" id="create-size-5" data-size="5">5</button>
+                <button class="difficulty-button" id="create-size-10" data-size="10">10</button>
+                <button class="difficulty-button" id="create-size-15" data-size="15">15</button>
+                <button class="difficulty-button" id="create-size-20" data-size="20">20</button>
+                <button class="difficulty-button" id="create-size-25" data-size="25">25</button>
+                <button class="difficulty-button" id="create-size-30" data-size="30">30</button>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="footer-left">
+            <div class="settings-group">
+                <button class="settings-button" id="settings-button" aria-haspopup="true" aria-expanded="false">size</button>
+                <button class="settings-button" id="seed-button">seed</button>
+            </div>
+        </div>
+        <div class="footer-center">
+            <p>o_n</p>
+            <a href="../nono/controls/">controls</a>
+            <a href="../privacy/">privacy</a>
+        </div>
+        <div class="footer-right">
+            <input type="file" id="upload-input" accept="image/*" class="file-input-hidden">
+            <button class="settings-button" id="upload-button">upload</button>
+        </div>
+    </footer>
+
+    <script src="../scripts/mobile-block.js" data-header="NONO_CREATE" data-message="nono create really needs a bigger screen"></script>
+    <script src="../scripts/darkmode.js"></script>
+    <script src="../scripts/fouc.js"></script>
+    <script src="../nono/seed.js"></script>
+    <script src="nono-create.js"></script>
+</body>
+</html>

--- a/docs/nono-create/nono-create.css
+++ b/docs/nono-create/nono-create.css
@@ -1,0 +1,214 @@
+:root {
+    --bg-color: white;
+    --color: black;
+    --board-length: min(85vmin, 85vh);
+    --creator-size: 15;
+    user-select: none;
+}
+
+.dark-mode {
+    --bg-color: black;
+    --color: white;
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    color: var(--color);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+}
+
+main {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.board-area {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 1rem;
+}
+
+.creator-board {
+    border-collapse: collapse;
+    width: var(--board-length);
+    height: var(--board-length);
+    background-color: var(--bg-color);
+    color: var(--color);
+    table-layout: fixed;
+}
+
+.creator-board tr {
+    padding: 0;
+    margin: 0;
+}
+
+.creator-cell {
+    width: calc(var(--board-length) / var(--creator-size));
+    height: calc(var(--board-length) / var(--creator-size));
+    border: 1px solid var(--color);
+    padding: 0;
+    margin: 0;
+    background-color: var(--bg-color);
+    transition: background-color 0.1s ease;
+    cursor: pointer;
+}
+
+.creator-cell:hover {
+    background-color: rgba(128, 128, 128, 0.2);
+}
+
+.creator-cell.filled {
+    background-color: blue;
+}
+
+.dark-mode .creator-cell.filled {
+    background-color: red;
+}
+
+.creator-board tr:first-child .creator-cell {
+    border-top-width: 3px;
+}
+
+.creator-board tr:nth-child(5n + 1) .creator-cell {
+    border-top-width: 3px;
+}
+
+.creator-board tr:last-child .creator-cell {
+    border-bottom-width: 3px;
+}
+
+.creator-board .creator-cell:first-child {
+    border-left-width: 3px;
+}
+
+.creator-board .creator-cell:nth-child(5n + 1) {
+    border-left-width: 3px;
+}
+
+.creator-board .creator-cell:last-child {
+    border-right-width: 3px;
+}
+
+footer {
+    width: min(85vmin, 95vw);
+    margin-bottom: 1.5rem;
+}
+
+.footer-left,
+.footer-right {
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.footer-left {
+    justify-content: flex-start;
+}
+
+.footer-right {
+    justify-content: flex-end;
+}
+
+.footer-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.footer-center a {
+    display: inline-block;
+}
+
+.settings-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.settings-button,
+.difficulty-button,
+button {
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+    font-size: 16px;
+    background-color: var(--bg-color);
+    color: var(--color);
+    border: none;
+}
+
+.settings-button:hover,
+.difficulty-button:hover,
+button:hover {
+    background-color: grey;
+}
+
+.settings-panel {
+    position: fixed;
+    left: calc(50% - (var(--board-length) / 2));
+    bottom: 5.5rem;
+    background: var(--bg-color);
+    color: var(--color);
+    padding: 1rem;
+    border: 1px solid var(--color);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+}
+
+.settings-panel.hidden {
+    display: none;
+}
+
+.difficulty-buttons-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+}
+
+.difficulty-button {
+    border: 1px solid var(--color);
+    padding: 0.25rem 0.5rem;
+}
+
+.difficulty-button.active {
+    background-color: blue;
+    color: white;
+}
+
+.dark-mode .difficulty-button.active {
+    background-color: red;
+    color: black;
+}
+
+.hidden {
+    display: none;
+}
+
+.file-input-hidden {
+    position: absolute;
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    z-index: -1;
+}
+
+@media (max-width: 768px) {
+    .settings-panel {
+        left: 1rem;
+        right: 1rem;
+    }
+}

--- a/docs/nono-create/nono-create.js
+++ b/docs/nono-create/nono-create.js
@@ -1,0 +1,328 @@
+(function () {
+  "use strict";
+
+  function createEmptyBoard(size) {
+    return Array.from({ length: size }, () => Array(size).fill(0));
+  }
+
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const boardElement = document.getElementById("creator-board");
+    const settingsButton = document.getElementById("settings-button");
+    const settingsPanel = document.getElementById("settings-panel");
+    const sizeButtons = Array.from(document.querySelectorAll(".difficulty-button"));
+    const seedButton = document.getElementById("seed-button");
+    const uploadButton = document.getElementById("upload-button");
+    const uploadInput = document.getElementById("upload-input");
+
+    if (!boardElement || !settingsButton || !settingsPanel) {
+      return;
+    }
+
+    const storedSizeId = localStorage.getItem("NONO_CREATE-currentSize");
+    const initialButton = storedSizeId ? document.getElementById(storedSizeId) : document.getElementById("create-size-15");
+    let size = Number(initialButton?.dataset.size ?? 15);
+    if (!Number.isFinite(size) || size <= 0) {
+      size = 15;
+    }
+
+    let board = createEmptyBoard(size);
+    let cellRefs = [];
+    let hoverCell = null;
+    let isMouseDown = false;
+    let paintValue = 1;
+
+    function setSizeVariable(value) {
+      document.documentElement.style.setProperty("--creator-size", String(value));
+    }
+
+    setSizeVariable(size);
+
+    function buildBoard() {
+      boardElement.innerHTML = "";
+      cellRefs = Array.from({ length: size }, () => new Array(size));
+      hoverCell = null;
+      isMouseDown = false;
+
+      for (let r = 0; r < size; r++) {
+        const rowEl = document.createElement("tr");
+        for (let c = 0; c < size; c++) {
+          const cell = document.createElement("td");
+          cell.className = "creator-cell";
+          cell.dataset.row = String(r);
+          cell.dataset.col = String(c);
+          rowEl.appendChild(cell);
+          cellRefs[r][c] = cell;
+        }
+        boardElement.appendChild(rowEl);
+      }
+
+      updateBoardUI();
+    }
+
+    function updateBoardUI() {
+      for (let r = 0; r < size; r++) {
+        for (let c = 0; c < size; c++) {
+          const cell = cellRefs[r]?.[c];
+          if (!cell) continue;
+          if (board[r][c]) {
+            cell.classList.add("filled");
+          } else {
+            cell.classList.remove("filled");
+          }
+        }
+      }
+    }
+
+    function setCell(row, col, value) {
+      row = clamp(row, 0, size - 1);
+      col = clamp(col, 0, size - 1);
+      if (board[row][col] === value) return;
+      board[row][col] = value;
+      const cell = cellRefs[row]?.[col];
+      if (cell) {
+        if (value) {
+          cell.classList.add("filled");
+        } else {
+          cell.classList.remove("filled");
+        }
+      }
+    }
+
+    function toggleCell(row, col) {
+      setCell(row, col, board[row][col] ? 0 : 1);
+    }
+
+    function handlePointerDown(event) {
+      const target = event.target.closest(".creator-cell");
+      if (!target) return;
+      event.preventDefault();
+      const row = Number(target.dataset.row);
+      const col = Number(target.dataset.col);
+      if (!Number.isFinite(row) || !Number.isFinite(col)) return;
+      isMouseDown = true;
+      paintValue = board[row][col] ? 0 : 1;
+      setCell(row, col, paintValue);
+    }
+
+    function handlePointerEnter(event) {
+      const target = event.target.closest(".creator-cell");
+      if (!target) return;
+      const row = Number(target.dataset.row);
+      const col = Number(target.dataset.col);
+      if (!Number.isFinite(row) || !Number.isFinite(col)) return;
+      hoverCell = { row, col };
+      if (isMouseDown) {
+        setCell(row, col, paintValue);
+      }
+    }
+
+    function handlePointerLeave() {
+      hoverCell = null;
+    }
+
+    function stopPainting() {
+      isMouseDown = false;
+    }
+
+    boardElement.addEventListener("mousedown", handlePointerDown);
+    boardElement.addEventListener("touchstart", (event) => {
+      if (event.touches?.length) {
+        const touch = event.touches[0];
+        const element = document.elementFromPoint(touch.clientX, touch.clientY);
+        if (element && boardElement.contains(element)) {
+          handlePointerDown({
+            target: element,
+            preventDefault: () => event.preventDefault(),
+          });
+        }
+      }
+    }, { passive: false });
+
+    boardElement.addEventListener("mouseover", handlePointerEnter);
+    boardElement.addEventListener("mousemove", handlePointerEnter);
+    boardElement.addEventListener("touchmove", (event) => {
+      if (!event.touches?.length) return;
+      const touch = event.touches[0];
+      const element = document.elementFromPoint(touch.clientX, touch.clientY);
+      if (element && boardElement.contains(element)) {
+        handlePointerEnter({ target: element });
+      }
+      event.preventDefault();
+    }, { passive: false });
+    boardElement.addEventListener("mouseleave", handlePointerLeave);
+
+    document.addEventListener("mouseup", stopPainting);
+    document.addEventListener("touchend", stopPainting);
+    document.addEventListener("touchcancel", stopPainting);
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key && event.key.toLowerCase() === "w" && hoverCell) {
+        event.preventDefault();
+        toggleCell(hoverCell.row, hoverCell.col);
+      }
+    });
+
+    function hideSettingsPanel() {
+      settingsPanel.classList.add("hidden");
+      settingsPanel.setAttribute("aria-hidden", "true");
+      settingsButton.setAttribute("aria-expanded", "false");
+    }
+
+    function showSettingsPanel() {
+      settingsPanel.classList.remove("hidden");
+      settingsPanel.setAttribute("aria-hidden", "false");
+      settingsButton.setAttribute("aria-expanded", "true");
+    }
+
+    settingsButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (settingsPanel.classList.contains("hidden")) {
+        showSettingsPanel();
+      } else {
+        hideSettingsPanel();
+      }
+    });
+
+    settingsPanel.addEventListener("click", (event) => {
+      event.stopPropagation();
+    });
+
+    document.addEventListener("click", (event) => {
+      if (!settingsPanel.contains(event.target) && event.target !== settingsButton) {
+        hideSettingsPanel();
+      }
+    });
+
+    document.addEventListener("contextmenu", (event) => {
+      if (!settingsPanel.contains(event.target) && event.target !== settingsButton) {
+        hideSettingsPanel();
+      }
+    });
+
+    sizeButtons.forEach((button) => {
+      const buttonSize = Number(button.dataset.size);
+      if (buttonSize === size) {
+        button.classList.add("active");
+      }
+      button.addEventListener("click", () => {
+        sizeButtons.forEach((btn) => btn.classList.remove("active"));
+        button.classList.add("active");
+        hideSettingsPanel();
+        const newSize = Number(button.dataset.size);
+        if (!Number.isFinite(newSize) || newSize <= 0) return;
+        size = newSize;
+        localStorage.setItem("NONO_CREATE-currentSize", button.id);
+        setSizeVariable(size);
+        board = createEmptyBoard(size);
+        buildBoard();
+      });
+    });
+
+    if (initialButton) {
+      sizeButtons.forEach((btn) => {
+        if (btn !== initialButton) {
+          btn.classList.remove("active");
+        }
+      });
+      initialButton.classList.add("active");
+    }
+
+    buildBoard();
+
+    if (seedButton) {
+      seedButton.addEventListener("click", async () => {
+        if (!window.Seed || typeof window.Seed.createSeedFromLayout !== "function") {
+          return;
+        }
+        try {
+          const seed = window.Seed.createSeedFromLayout(board, size);
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(seed);
+            seedButton.textContent = "copied";
+            setTimeout(() => {
+              seedButton.textContent = "seed";
+            }, 1200);
+          } else {
+            window.prompt("Seed", seed);
+          }
+        } catch (error) {
+          console.error("Unable to copy seed", error);
+          seedButton.textContent = "error";
+          setTimeout(() => {
+            seedButton.textContent = "seed";
+          }, 1500);
+        }
+      });
+    }
+
+    function applyBoardFromImageData(imageData, width, height) {
+      const newBoard = createEmptyBoard(size);
+      for (let r = 0; r < size; r++) {
+        for (let c = 0; c < size; c++) {
+          const sampleX = Math.floor((c / size) * width);
+          const sampleY = Math.floor((r / size) * height);
+          const clampedX = clamp(sampleX, 0, width - 1);
+          const clampedY = clamp(sampleY, 0, height - 1);
+          const idx = (clampedY * width + clampedX) * 4;
+          const red = imageData[idx];
+          const green = imageData[idx + 1];
+          const blue = imageData[idx + 2];
+          const alpha = imageData[idx + 3] / 255;
+          const brightness = (red + green + blue) / 3;
+          const value = alpha < 0.1 ? 0 : brightness < 128 ? 1 : 0;
+          newBoard[r][c] = value;
+        }
+      }
+      board = newBoard;
+      buildBoard();
+    }
+
+    function handleFile(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const img = new Image();
+          img.onload = () => {
+            const canvas = document.createElement("canvas");
+            canvas.width = size;
+            canvas.height = size;
+            const ctx = canvas.getContext("2d");
+            if (!ctx) {
+              reject(new Error("Canvas context not available"));
+              return;
+            }
+            ctx.drawImage(img, 0, 0, size, size);
+            const imageData = ctx.getImageData(0, 0, size, size);
+            resolve({ data: imageData.data, width: imageData.width, height: imageData.height });
+          };
+          img.onerror = () => reject(new Error("Unable to load image"));
+          img.src = reader.result;
+        };
+        reader.onerror = () => reject(new Error("Unable to read file"));
+        reader.readAsDataURL(file);
+      });
+    }
+
+    if (uploadButton && uploadInput) {
+      uploadButton.addEventListener("click", () => {
+        uploadInput.value = "";
+        uploadInput.click();
+      });
+
+      uploadInput.addEventListener("change", async () => {
+        const file = uploadInput.files?.[0];
+        if (!file) return;
+        try {
+          const { data, width, height } = await handleFile(file);
+          applyBoardFromImageData(data, width, height);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+    }
+  });
+})();

--- a/docs/nono/index.html
+++ b/docs/nono/index.html
@@ -51,6 +51,7 @@
         </div>
         <p>o_n</p>
         <a href="controls/">controls</a>
+        <a href="../nono-create/">create</a>
         <a href="../privacy/">privacy</a>
         <div id="win-paste" class="win-paste hidden">
             <div id="reset-hint" class="reset-hint hidden"></div>


### PR DESCRIPTION
## Summary
- add a NONO_CREATE page that mirrors the game layout and lets players design custom puzzles
- implement interactive drawing, keyboard toggling, seed copying, and image-to-board conversion for the creator grid
- link the new creator experience from the original NONO footer for quick access

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68dc584722dc8321b7b428314ea542a0