### PR TITLE
Align nono-create settings panel styles with nono

### DIFF
--- a/docs/nono-create/nono-create.css
+++ b/docs/nono-create/nono-create.css
@@ -185,15 +185,18 @@ button:hover {
 }
 
 .settings-panel {
-  position: absolute;
-  left: calc(50% - (var(--board-length) / 2));
-  bottom: 5.5rem;
-  background: var(--bg-color);
-  color: var(--color);
-  padding: 1rem;
-  border: 1px solid var(--color);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-  z-index: 1000;
+    position: absolute;
+    margin-left: 0.2rem;
+    flex: 1;
+    padding: 1rem;
+    background-color: var(--bg-color);
+    left: 0;
+    font-size: 1rem;
+    max-width: 90vw;
+}
+
+.settings-panel {
+    padding: 1rem;
 }
 
 .settings-panel.hidden {


### PR DESCRIPTION
## Summary
- copy the settings panel styling from `docs/nono/nono.css` into `docs/nono-create/nono-create.css` for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc6819f4d48321991a9f0f93409f62