### PR TITLE
Adjust nono board size picker layout

### DIFF
--- a/docs/nono/index.html
+++ b/docs/nono/index.html
@@ -30,20 +30,17 @@
     <main>
         <table border="1" id="game-container" class="game-container"></table>
 
-        <div id="settings-panel" class="settings-panel hidden">
-            <div id="difficulty-buttons-grid" class="difficulty-buttons-grid">
-                <button class="difficulty-button" id="difficulty-5" data-size="5" data-font="16px">5</button>
-                <button class="difficulty-button" id="difficulty-10" data-size="10" data-font="16px">10</button>
-                <button class="difficulty-button" id="difficulty-15" data-size="15" data-font="16px">15</button>
-                <button class="difficulty-button" id="difficulty-20" data-size="20" data-font="16px">20</button>
-                <button class="difficulty-button" id="difficulty-25" data-size="25" data-font="16px">25</button>
-                <button class="difficulty-button" id="difficulty-30" data-size="30" data-font="16px">30</button>
-            </div>
-        </div>
-
     </main>
 
     <footer>
+        <div id="settings-panel" class="settings-panel hidden">
+            <button class="difficulty-button" id="difficulty-5" data-size="5" data-font="16px">5</button>
+            <button class="difficulty-button" id="difficulty-10" data-size="10" data-font="16px">10</button>
+            <button class="difficulty-button" id="difficulty-15" data-size="15" data-font="16px">15</button>
+            <button class="difficulty-button" id="difficulty-20" data-size="20" data-font="16px">20</button>
+            <button class="difficulty-button" id="difficulty-25" data-size="25" data-font="16px">25</button>
+            <button class="difficulty-button" id="difficulty-30" data-size="30" data-font="16px">30</button>
+        </div>
         <div class="settings-group">
             <button class="settings-button" id="settings-button">size</button>
             <button class="settings-button" id="seed-button">seed</button>

--- a/docs/nono/nono.css
+++ b/docs/nono/nono.css
@@ -257,20 +257,8 @@ table tr:last-child td.drag-preview {
 }
 
 .settings-panel {
-    position: absolute;
-    margin-left: 0.2rem;
-    flex: 1;
-    padding: 1rem;
     background-color: var(--bg-color);
-    left: 0;
     font-size: 1rem;
-    max-width: 90vw;
-}
-
-.difficulty-buttons-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.5rem;
 }
 
 .difficulty-button{
@@ -321,11 +309,6 @@ button:hover {
     background-color: grey;
 }
 
-.settings-button {
-    position: absolute;
-    left: calc(1rem + 4px);
-}
-
 .win-paste {
     display: flex;
     flex-direction: row;
@@ -359,6 +342,23 @@ button:hover {
     /* color: red; */
 }
 
+#settings-panel {
+    position: absolute;
+    left: calc(1rem + 4px);
+    bottom: 2.8rem;
+    display: none;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid var(--color);
+    border-radius: 4px;
+    z-index: 1000;
+    align-items: center;
+}
+
+#settings-panel:not(.hidden) {
+    display: flex;
+}
+
 .settings-group {
     position: absolute;
     left: calc(1rem + 4px);
@@ -371,10 +371,6 @@ button:hover {
 /* When buttons are inside the group, don't absolutely position each button */
 .settings-group .settings-button {
     position: static;
-}
-
-.settings-panel{
-    padding: 1rem;
 }
 
 #load-panel{

--- a/docs/nono/nono.js
+++ b/docs/nono/nono.js
@@ -2,10 +2,19 @@
 document.addEventListener('DOMContentLoaded', () => {
     const settingsButton = document.getElementById('settings-button');
     const settingsPanel = document.getElementById('settings-panel');
+    const loadPanel = document.getElementById('load-panel');
 
     settingsButton.addEventListener('click', (e) => {
-        settingsPanel.classList.toggle('hidden');
-        e.stopPropagation(); 
+        const isHidden = settingsPanel.classList.contains('hidden');
+        if (isHidden) {
+            settingsPanel.classList.remove('hidden');
+            if (loadPanel) {
+                loadPanel.classList.add('hidden');
+            }
+        } else {
+            settingsPanel.classList.add('hidden');
+        }
+        e.stopPropagation();
     });
 
     document.addEventListener('click', (e) => {
@@ -51,6 +60,7 @@ class Nono {
             document.documentElement.style.setProperty('--num-font-size', '16px');
         }
 
+        const settingsPanelEl = document.getElementById('settings-panel');
         const sizeButtons = document.querySelectorAll('.difficulty-button');
         sizeButtons.forEach(button => {
             button.addEventListener('click', () => {
@@ -67,6 +77,8 @@ class Nono {
                 document.documentElement.style.setProperty('--num-font-size', document.getElementById(this.sizeMode)?.dataset.font ?? button.dataset.font);
 
                 this.reset();
+
+                settingsPanelEl?.classList.add('hidden');
 
             });
         });
@@ -191,6 +203,8 @@ class Nono {
                     loadPanel.classList.add('hidden');
                     seedInput.value = '';
                 }
+                const settingsPanel = document.getElementById('settings-panel');
+                settingsPanel?.classList.add('hidden');
             });
 
             cancelBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- relocate the size selection buttons to the footer so they appear above the size control like the load panel
- restyle the size picker as a horizontal row of difficulty buttons and hide it after a choice is made
- ensure the load and size panels do not overlap by closing the other panel when one is opened

## Testing
- Manual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc8a494db483218c088739104f5eaf