### PR TITLE
Improve Nonogram board sizing constraints

### DIFF
--- a/docs/nono/nono.css
+++ b/docs/nono/nono.css
@@ -97,11 +97,14 @@ main {
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: auto;
 }
 
 .game-container {
-    min-width: 85vmin;
-    min-height: 85vmin;
+    width: clamp(85vmin, max-content, min(1200px, 95vw));
+    height: clamp(85vmin, max-content, min(1200px, 95vw));
+    max-inline-size: min(1200px, 95vw);
+    max-block-size: min(1200px, 95vw);
     /* table-layout: fixed; */
     border-collapse: collapse;
     background-color: var(--bg-color);


### PR DESCRIPTION
## Summary
- clamp the nonogram game container sizing to prevent runaway growth while accommodating clues
- allow the main layout area to scroll when the board exceeds the viewport

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e35b9e5c808321b2723570107859e8